### PR TITLE
#5 switch to use sequelize v4 lt operator

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ class BruteStore extends AbstractClientStore {
     let clause = { truncate: true };
 
     if (typeof lifetime == 'number') {
-      clause = { where: { updatedAt: { $lt: new Date(Date.now() - lifetime * 1000) } } };
+      clause = { where: { updatedAt: { [Sequelize.Op.lt]: new Date(Date.now() - lifetime * 1000) } } };
     }
 
     return this.model.destroy(clause).then(() => {

--- a/test/test.js
+++ b/test/test.js
@@ -92,17 +92,26 @@ describe('ExpressBruteStoreSequelize:', function () {
   });
 
   describe('#clear()', function () {
-    it('check clearing', function () {
+    it('check clearing lifetime', function () {
       return store.set(key, data, lifetime).then(() => {
         return store.clear(2).then(() => {
           return store.model.count().then((count) => {
             assert.equal(count, 1);
           });
         }).then(() => {
-          return store.clear().then(() => {
+          return store.clear(-2).then(() => {
             return store.model.count().then((count) => {
               assert.equal(count, 0);
             });
+          });
+        });
+      });
+    });
+    it('check clearing truncate', function () {
+      return store.set(key, data, lifetime).then(() => {
+        return store.clear().then(() => {
+          return store.model.count().then((count) => {
+            assert.equal(count, 0);
           });
         });
       });


### PR DESCRIPTION
Tiny fix for #5

Since the dependencies were bumped to Sequelize v4 just went ahead and used the new operators.

